### PR TITLE
-webkit-line-clamp를 unset으로, fallback으로 inherit 추가

### DIFF
--- a/src/components/UnitDetailView/styles.js
+++ b/src/components/UnitDetailView/styles.js
@@ -145,7 +145,7 @@ export const bookDescriptionFolded = (line, lineHeight) => ({
 });
 export const bookDescriptionExpended = {
   maxHeight: 'inherit',
-  WebkitLineClamp: 'inherit',
+  WebkitLineClamp: ['inherit', 'unset'],
 };
 export const bookDescriptionExpend = {
   textAlign: 'right',


### PR DESCRIPTION
마지막에 오는 유효 값이 적용되기 때문에 `unset`을 뒤에 놓았습니다.