### PR TITLE
책장 선택 컴포넌트에 페이지네이터 추가

### DIFF
--- a/src/components/Paginator/index.jsx
+++ b/src/components/Paginator/index.jsx
@@ -1,6 +1,5 @@
 /** @jsx jsx */
 import React from 'react';
-import Link from 'next/link';
 import { jsx } from '@emotion/core';
 
 import * as styles from './styles';
@@ -8,17 +7,24 @@ import NoneDashedArrowLeft from '../../svgs/NoneDashedArrowLeft.svg';
 import NoneDashedArrowRight from '../../svgs/NoneDashedArrowRight.svg';
 import ThreeDotsHorizontal from '../../svgs/ThreeDotsHorizontal.svg';
 import { calcPageBlock, makePageRange } from '../../utils/pagination';
-import { makeLinkProps } from '../../utils/uri';
 
-export default class Paginator extends React.Component {
-  getLinkProps(page) {
-    const { href, as, query = {} } = this.props;
-    return makeLinkProps(href, as, { ...query, page });
+function NavigationButton(props) {
+  const { children, onPageChange, page, style } = props;
+  const handleClick = React.useCallback(() => onPageChange(page), [onPageChange, page]);
+  return (
+    <button type="button" css={[styles.pageButton, style]} onClick={handleClick}>
+      {children}
+    </button>
+  );
+}
+
+export default function Paginator(props) {
+  const { currentPage, needGoFirst, needGoLast, onPageChange, pageCount, style, totalPages } = props;
+  if (totalPages <= 1 || currentPage < 1 || currentPage > totalPages) {
+    return null;
   }
 
-  renderGoFirst() {
-    const { currentPage, pageCount } = this.props;
-
+  function renderGoFirst() {
     if (currentPage <= pageCount) {
       return null;
     }
@@ -26,9 +32,9 @@ export default class Paginator extends React.Component {
     return (
       <>
         <div css={styles.buttonWrapper}>
-          <Link prefetch {...this.getLinkProps(1)}>
-            <a css={[styles.pageButton, styles.textButton]}>처음</a>
-          </Link>
+          <NavigationButton style={styles.textButton} onPageChange={onPageChange} page={1}>
+            처음
+          </NavigationButton>
         </div>
         <span css={styles.paginatorDots}>
           <ThreeDotsHorizontal css={styles.dots} />
@@ -37,9 +43,7 @@ export default class Paginator extends React.Component {
     );
   }
 
-  renderGoLast() {
-    const { currentPage, totalPages, pageCount } = this.props;
-
+  function renderGoLast() {
     if (calcPageBlock(currentPage, pageCount) === calcPageBlock(totalPages, pageCount)) {
       return null;
     }
@@ -50,17 +54,15 @@ export default class Paginator extends React.Component {
           <ThreeDotsHorizontal css={styles.dots} />
         </span>
         <div css={styles.buttonWrapper}>
-          <Link prefetch {...this.getLinkProps(totalPages)}>
-            <a css={[styles.pageButton, styles.textButton]}>마지막</a>
-          </Link>
+          <NavigationButton style={styles.textButton} onPageChange={onPageChange} page={totalPages}>
+            마지막
+          </NavigationButton>
         </div>
       </>
     );
   }
 
-  renderGoPrev() {
-    const { currentPage, pageCount } = this.props;
-
+  function renderGoPrev() {
     // 첫 페이지와 같은 블록이면 노출하지 않는다.
     if (calcPageBlock(currentPage, pageCount) === calcPageBlock(1, pageCount)) {
       return null;
@@ -72,19 +74,15 @@ export default class Paginator extends React.Component {
 
     return (
       <div css={styles.buttonWrapper}>
-        <Link prefetch {...this.getLinkProps(firstPrevBlockPage)}>
-          <a css={styles.pageButton}>
-            <NoneDashedArrowLeft css={styles.pageItemIcon} />
-            <span className="a11y">이전 페이지</span>
-          </a>
-        </Link>
+        <NavigationButton onPageChange={onPageChange} page={firstPrevBlockPage}>
+          <NoneDashedArrowLeft css={styles.pageItemIcon} />
+          <span className="a11y">이전 페이지</span>
+        </NavigationButton>
       </div>
     );
   }
 
-  renderGoNext() {
-    const { currentPage, totalPages, pageCount } = this.props;
-
+  function renderGoNext() {
     // 마지막 페이지와 같은 블록이면 노출하지 않는다.
     if (calcPageBlock(currentPage, pageCount) === calcPageBlock(totalPages, pageCount)) {
       return null;
@@ -96,47 +94,37 @@ export default class Paginator extends React.Component {
 
     return (
       <div css={styles.buttonWrapper}>
-        <Link prefetch {...this.getLinkProps(firstNextBlockPage)}>
-          <a css={styles.pageButton}>
-            <NoneDashedArrowRight css={styles.pageItemIcon} />
-            <span className="a11y">다음 페이지</span>
-          </a>
-        </Link>
+        <NavigationButton onPageChange={onPageChange} page={firstNextBlockPage}>
+          <NoneDashedArrowRight css={styles.pageItemIcon} />
+          <span className="a11y">다음 페이지</span>
+        </NavigationButton>
       </div>
     );
   }
 
-  renderPageItems() {
-    const { currentPage, totalPages, pageCount } = this.props;
+  function renderPageItems() {
     const pageRange = makePageRange(currentPage, totalPages, pageCount);
 
     return (
       <ul css={styles.pageItems}>
         {pageRange.map(page => (
           <li key={page} css={styles.pageItem}>
-            <Link prefetch {...this.getLinkProps(page)}>
-              <a css={[styles.pageButton, currentPage === page && styles.pageButtonActive]}>{page}</a>
-            </Link>
+            <NavigationButton style={currentPage === page && styles.pageButtonActive} onPageChange={onPageChange} page={page}>
+              {page}
+            </NavigationButton>
           </li>
         ))}
       </ul>
     );
   }
 
-  render() {
-    const { currentPage, totalPages, style, needGoFirst, needGoLast } = this.props;
-    if (totalPages <= 1 || currentPage < 1 || currentPage > totalPages) {
-      return null;
-    }
-
-    return (
-      <div css={[styles.paginator, style]}>
-        {needGoFirst && this.renderGoFirst()}
-        {this.renderGoPrev()}
-        {this.renderPageItems()}
-        {this.renderGoNext()}
-        {needGoLast && this.renderGoLast()}
-      </div>
-    );
-  }
+  return (
+    <div css={[styles.paginator, style]}>
+      {needGoFirst && renderGoFirst()}
+      {renderGoPrev()}
+      {renderPageItems()}
+      {renderGoNext()}
+      {needGoLast && renderGoLast()}
+    </div>
+  );
 }

--- a/src/components/ResponsivePaginator.jsx
+++ b/src/components/ResponsivePaginator.jsx
@@ -1,6 +1,9 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
+import Router from 'next/router';
+import React from 'react';
 import { MOBILE_PAGE_COUNT, PAGE_COUNT } from '../constants/page';
+import { makeLinkProps } from '../utils/uri';
 import { MQ, Responsive } from '../styles/responsive';
 import Paginator from './Paginator';
 
@@ -23,29 +26,37 @@ const styles = {
   },
 };
 
-const ResponsivePaginator = ({ currentPage, totalPages, href, as, query }) => (
-  <>
-    <Paginator
-      style={styles.pc}
-      currentPage={currentPage}
-      totalPages={totalPages}
-      pageCount={PAGE_COUNT}
-      href={href}
-      as={as}
-      query={query}
-      needGoFirst
-      needGoLast
-    />
-    <Paginator
-      style={styles.mobile}
-      currentPage={currentPage}
-      totalPages={totalPages}
-      pageCount={MOBILE_PAGE_COUNT}
-      href={href}
-      as={as}
-      query={query}
-    />
-  </>
-);
+export const ResponsivePaginatorWithHandler = ({ currentPage, totalPages, onPageChange }) => {
+  const commonProps = {
+    currentPage,
+    totalPages,
+    onPageChange,
+  };
+  return (
+    <>
+      <Paginator style={styles.pc} pageCount={PAGE_COUNT} needGoFirst needGoLast {...commonProps} />
+      <Paginator style={styles.mobile} pageCount={MOBILE_PAGE_COUNT} {...commonProps} />
+    </>
+  );
+};
+
+const ResponsivePaginator = ({ currentPage, totalPages, href, as, query, scroll }) => {
+  const handlePageChange = React.useCallback(
+    page => {
+      const newQuery = query || {};
+      const linkProps = makeLinkProps(href, as, { ...newQuery, page });
+      Router.push(linkProps.href, linkProps.as);
+
+      // next/link의 로직
+      const doScrollTop = scroll == null ? !linkProps.as.pathname.includes('#') : scroll;
+      if (doScrollTop) {
+        window.scrollTo(0, 0);
+        document.body.focus();
+      }
+    },
+    [href, as, query, scroll],
+  );
+  return <ResponsivePaginatorWithHandler currentPage={currentPage} totalPages={totalPages} onPageChange={handlePageChange} />;
+};
 
 export default ResponsivePaginator;


### PR DESCRIPTION
기존 페이지네이터는 `Link`를 바로 사용해 URL 변경 없이는 사용할 수 없었습니다. 이번에 페이지네이터가 페이지 변경 이벤트만을 발생시키도록 수정하고, 기존에 사용하던 라우터와 연결된 페이지네이터는 새 페이지네이터를 감싸는 방식으로 구현했습니다.