### PR TITLE
책장 선택할 때 새 책장 만들 수 있도록 함

### DIFF
--- a/src/components/SelectShelfModal/index.jsx
+++ b/src/components/SelectShelfModal/index.jsx
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 
 import { SHELVES_LIMIT_PER_PAGE } from '../../constants/page';
 import Responsive from '../../pages/base/Responsive';
+import * as promptActions from '../../services/prompt/actions';
 import * as shelfActions from '../../services/shelf/actions';
 import * as shelfSelectors from '../../services/shelf/selectors';
 import * as paginationUtils from '../../utils/pagination';
@@ -15,6 +16,7 @@ import { ResponsivePaginatorWithHandler } from '../ResponsivePaginator';
 import { shelfStyles } from '../Shelf/styles';
 import { Shelves } from '../Shelves';
 import { SkeletonShelves } from '../Skeleton/SkeletonShelves';
+import * as Tool from '../Tool';
 import NavigationBar from './NavigationBar';
 
 const toolBar = css`
@@ -34,9 +36,33 @@ function SelectShelfLinkButton(props) {
 }
 
 function SelectShelfModalInner(props) {
-  const { loadShelfCount, loadShelves, onPageOptionsChange, orderBy, orderDirection, page, shelves, totalShelfCount } = props;
+  const {
+    addShelf,
+    loadShelfCount,
+    loadShelves,
+    onPageOptionsChange,
+    orderBy,
+    orderDirection,
+    page,
+    shelves,
+    showPrompt,
+    totalShelfCount,
+  } = props;
   const totalPages = totalShelfCount == null ? null : paginationUtils.calcPage(totalShelfCount, SHELVES_LIMIT_PER_PAGE);
   const handlePageChange = React.useCallback(newPage => onPageOptionsChange({ page: newPage }), [onPageOptionsChange]);
+  const handleAddShelf = React.useCallback(
+    () => {
+      showPrompt({
+        title: '새 책장 추가',
+        message: '새 책장의 이름을 입력해주세요.',
+        emptyInputAlertMessage: '책장의 이름을 입력해주세요.',
+        onClickConfirmButton: shelfName => {
+          addShelf({ name: shelfName, pageOptions: { orderBy, orderDirection, page } });
+        },
+      });
+    },
+    [orderBy, orderDirection, page],
+  );
 
   React.useEffect(() => {
     loadShelfCount();
@@ -51,10 +77,11 @@ function SelectShelfModalInner(props) {
 
   function renderToolBar() {
     const { onBackClick } = props;
+    const right = <Tool.Add onClickAddButton={handleAddShelf} />;
     return (
       <>
         <NavigationBar onBackClick={onBackClick} />
-        <FlexBar css={toolBar} />
+        <FlexBar css={toolBar} flexLeft={<div />} flexRight={right} />
       </>
     );
   }
@@ -103,6 +130,8 @@ function mapStateToProps(state, props) {
 const mapDispatchToProps = {
   loadShelfCount: shelfActions.loadShelfCount,
   loadShelves: shelfActions.loadShelves,
+  showPrompt: promptActions.showPrompt,
+  addShelf: shelfActions.addShelf,
 };
 
 const SelectShelfModal = connect(

--- a/src/components/Tool/index.jsx
+++ b/src/components/Tool/index.jsx
@@ -1,5 +1,6 @@
+import { Add } from './Add';
 import Filter from './Filter';
 import Editing from './Editing';
 import More from './More';
 
-export { Filter, Editing, More };
+export { Add, Filter, Editing, More };


### PR DESCRIPTION
코드 짜면서 생각한 건데, 이벤트 핸들러가 필요한 모달 창은 redux로 보내지 않고 컴포넌트가 직접 렌더링하는 게 낫지 않을까 하는 생각이 들어요. 이벤트 핸들러 들고 있는 부모 컴포넌트가 사라지면 모달만 남아서 의도하지 않은 현상이 생길 수도 있고, Hooks를 사용하면 정확한 행동을 보장하기가 더 힘드네요.