### PR TITLE
책장에서 책 다운로드할 때 대표도서만 다운로드되는 문제 수정

### DIFF
--- a/src/pages/shelves/detail/index.jsx
+++ b/src/pages/shelves/detail/index.jsx
@@ -19,7 +19,6 @@ import { LIBRARY_ITEMS_LIMIT_PER_PAGE } from '../../../constants/page';
 import { PageType, URLMap } from '../../../constants/urls';
 import ViewType from '../../../constants/viewType';
 import * as bookSelectors from '../../../services/book/selectors';
-import * as bookDownloadActions from '../../../services/bookDownload/actions';
 import * as confirmActions from '../../../services/confirm/actions';
 import * as promptActions from '../../../services/prompt/actions';
 import * as selectionActions from '../../../services/selection/actions';
@@ -65,7 +64,7 @@ function ShelfDetail(props) {
     bookIds,
     clearSelectedBooks,
     removeShelfFromDetail,
-    downloadSelectedBooks,
+    downloadSelectedUnits,
     name,
     orderBy,
     orderDirection,
@@ -104,7 +103,7 @@ function ShelfDetail(props) {
     });
   }, []);
   const downloadBooks = React.useCallback(() => {
-    downloadSelectedBooks();
+    downloadSelectedUnits();
     clearSelectedBooks();
     setIsEditing(false);
   }, []);
@@ -369,7 +368,7 @@ const mapDispatchToProps = {
   addSelectedToShelf: actions.addSelectedToShelf,
   clearSelectedBooks: selectionActions.clearSelectedItems,
   removeShelfFromDetail: actions.deleteShelfFromDetail,
-  downloadSelectedBooks: bookDownloadActions.downloadSelectedBooks,
+  downloadSelectedUnits: actions.downloadSelectedUnits,
   removeSelectedFromShelf: actions.removeSelectedFromShelf,
   renameShelf: actions.renameShelf,
   selectBooks: selectionActions.selectItems,

--- a/src/services/shelf/actions.js
+++ b/src/services/shelf/actions.js
@@ -26,6 +26,7 @@ export const VALIDATE_SHELVES_LIMIT = 'VALIDATE_SHELVES_LIMIT';
 export const DELETE_SHELF_FROM_DETAIL = 'DELETE_SHELF_FROM_DETAIL';
 export const ADD_SELECTED_TO_SHELF = 'ADD_SELECTED_TO_SHELF';
 export const REMOVE_SELECTED_FROM_SHELF = 'REMOVE_SELECTED_FROM_SHELF';
+export const DOWNLOAD_SELECTED_UNITS = 'DOWNLOAD_SELECTED_UNITS';
 
 export const BEGIN_OPERATION = 'BEGIN_OPERATION';
 export const END_OPERATION = 'END_OPERATION';
@@ -221,6 +222,10 @@ export const removeSelectedFromShelf = ({ uuid, pageOptions }) => ({
     uuid,
     pageOptions,
   },
+});
+
+export const downloadSelectedUnits = () => ({
+  type: DOWNLOAD_SELECTED_UNITS,
 });
 
 export const beginOperation = ({ revision }) => ({

--- a/src/services/shelf/sagas.js
+++ b/src/services/shelf/sagas.js
@@ -10,6 +10,8 @@ import { makeLinkProps } from '../../utils/uri';
 import * as bookRequests from '../book/requests';
 import * as bookSagas from '../book/sagas';
 import * as bookDownloadActions from '../bookDownload/actions';
+import { MakeBookIdsError } from '../common/errors';
+import * as dialogActions from '../dialog/actions';
 import * as selectionActions from '../selection/actions';
 import * as selectionSelectors from '../selection/selectors';
 import * as toastActions from '../toast/actions';
@@ -362,7 +364,15 @@ function* downloadSelectedUnits() {
     .map(([bookId]) => bookId);
   const bookToUnit = yield select(state => state.shelf.bookToUnit);
   const unitIds = bookIds.map(bookId => bookToUnit[bookId]);
-  yield put(bookDownloadActions.downloadBooksByUnitIds(unitIds));
+  try {
+    yield put(bookDownloadActions.downloadBooksByUnitIds(unitIds));
+  } catch (err) {
+    let message = '일시적인 오류가 발생했습니다. 잠시 후 다시 시도해주세요.';
+    if (err instanceof MakeBookIdsError) {
+      message = '다운로드 대상 도서의 정보 구성 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.';
+    }
+    yield put(dialogActions.showDialog('다운로드 오류', message));
+  }
 }
 
 export default function* shelfRootSaga(isServer) {

--- a/src/services/shelf/sagas.js
+++ b/src/services/shelf/sagas.js
@@ -9,6 +9,7 @@ import { thousandsSeperator } from '../../utils/number';
 import { makeLinkProps } from '../../utils/uri';
 import * as bookRequests from '../book/requests';
 import * as bookSagas from '../book/sagas';
+import * as bookDownloadActions from '../bookDownload/actions';
 import * as selectionActions from '../selection/actions';
 import * as selectionSelectors from '../selection/selectors';
 import * as toastActions from '../toast/actions';
@@ -355,6 +356,15 @@ function* removeSelectedFromShelf({ payload }) {
   yield put(actions.loadShelfBooks(uuid, pageOptions));
 }
 
+function* downloadSelectedUnits() {
+  const bookIds = Object.entries(yield select(selectionSelectors.getSelectedItems))
+    .filter(([, checked]) => checked)
+    .map(([bookId]) => bookId);
+  const bookToUnit = yield select(state => state.shelf.bookToUnit);
+  const unitIds = bookIds.map(bookId => bookToUnit[bookId]);
+  yield put(bookDownloadActions.downloadBooksByUnitIds(unitIds));
+}
+
 export default function* shelfRootSaga(isServer) {
   yield all([
     takeEvery(actions.LOAD_SHELVES, loadShelves, isServer),
@@ -370,6 +380,7 @@ export default function* shelfRootSaga(isServer) {
     takeEvery(actions.DELETE_SHELF_FROM_DETAIL, deleteShelfFromDetail),
     takeEvery(actions.ADD_SELECTED_TO_SHELF, addSelectedToShelf),
     takeEvery(actions.REMOVE_SELECTED_FROM_SHELF, removeSelectedFromShelf),
+    takeEvery(actions.DOWNLOAD_SELECTED_UNITS, downloadSelectedUnits),
     takeEvery(actions.VALIDATE_SHELVES_LIMIT, validateShelvesLimit),
   ]);
 }


### PR DESCRIPTION
Redux DevTools에서 책 목록이 모두 넘어가는 걸 확인했습니다.