### PR TITLE
검색창 X 버튼이 입력칸에 포커스가 있을 때 작동하지 않는 문제 수정

### DIFF
--- a/src/components/IconButton.jsx
+++ b/src/components/IconButton.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-const IconButton = ({ a11y, onClick, className, children }) => (
-  <button type="button" onClick={onClick} className={className}>
+const IconButton = ({ a11y, children, ...buttonProps }) => (
+  <button type="button" {...buttonProps}>
     {children}
     <span className="a11y">{a11y}</span>
   </button>

--- a/src/components/SearchBox.jsx
+++ b/src/components/SearchBox.jsx
@@ -135,6 +135,8 @@ export default function SearchBox({ isSearchPage, keyword, onBlur, onClear, onFo
         a11y="검색어 제거"
         css={[styles.clearButton, (isSearchBoxFocused || keyword) && styles.clearButtonActive]}
         onClick={handleCancel}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
       >
         <Close css={styles.clearIcon} />
       </IconButton>


### PR DESCRIPTION
X 버튼을 누르면 클릭 이벤트가 발생하기 전에 포커스가 버튼으로 이동하는데 이렇게 되면 버튼이 이동해 클릭 이벤트가 발생하지 않습니다. 버튼으로 포커스가 이동했을 때도 입력칸에 포커스가 있는 것처럼 취급해 해결했습니다.