### PR TITLE
책장내 도서상세 페이지 Link 이슈 대응

### DIFF
--- a/src/pages/shelves/detail/index.jsx
+++ b/src/pages/shelves/detail/index.jsx
@@ -156,7 +156,7 @@ function ShelfDetail(props) {
         </Link>
       );
     },
-    [uuid],
+    [location],
   );
 
   React.useEffect(


### PR DESCRIPTION
backLocation 생성부가 업데이트 되지 않아 책장 도서 상세에서 책장으로 돌아갈때 항상 첫페이지로 이동하는 이슈 대응 