### PR TITLE
마우스가 없는 환경에서 hover 스타일 적용하지 않도록 함

### DIFF
--- a/src/components/Shelf/styles.js
+++ b/src/components/Shelf/styles.js
@@ -57,6 +57,13 @@ export const shelfStyles = {
       transform: translate3d(0, -4px, 0);
       box-shadow: 4px 4px 8px 0 rgba(0, 0, 0, 0.1);
     }
+    // IE에서 안 되지만 어차피 모바일 버전이 없으니 상관 없음
+    @media (hover: none) {
+      &:hover {
+        transform: translate3d(0, 0, 0);
+        box-shadow: 0 0 0 0 rgba(0, 0, 0, 0);
+      }
+    }
   `,
   thumbnails: css`
     display: flex;


### PR DESCRIPTION
데스크톱에서 책장 위에 마우스 포인터를 올리면 살짝 떠오르는 애니메이션이 있는데, 이것이 모바일 기기에서는 보이지 않게 합니다.