### PR TITLE
스크롤 관리 컴포넌트 작성

### DIFF
--- a/src/ScrollManager.jsx
+++ b/src/ScrollManager.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { withRouter } from 'react-router-dom';
+
+function ScrollManager({ location }) {
+  const previousLocation = React.useRef(null);
+  const scrollPositionMap = React.useRef(new Map());
+  const scrollPosition = React.useRef({ x: 0, y: 0 });
+
+  React.useEffect(() => {
+    scrollPosition.current.x = window.scrollX;
+    scrollPosition.current.y = window.scrollY;
+  }, []);
+
+  React.useEffect(
+    () => {
+      const positionMap = scrollPositionMap.current;
+      if (previousLocation.current != null) {
+        // 여기서 window의 스크롤 위치를 캡처하면 이전 상태를 가져올 수 없다
+        // 내용이 짧아져 스크롤이 이동했을 수 있기 때문...
+        positionMap.set(previousLocation.current.key, { ...scrollPosition.current });
+      }
+      previousLocation.current = location;
+
+      const handleScroll = () => {
+        scrollPosition.current.x = window.scrollX;
+        scrollPosition.current.y = window.scrollY;
+      };
+      window.addEventListener('scroll', handleScroll);
+
+      const { key, state } = location;
+      if (positionMap.has(key)) {
+        // 방문한 적 있는 페이지, 브라우저가 스크롤 위치를 복구하므로 그에 따라간다
+        scrollPosition.current.x = window.scrollX;
+        scrollPosition.current.y = window.scrollY;
+      } else {
+        // state에 주어진 명령에 따라 스크롤 위치를 조작한다
+        let position = { x: 0, y: 0 };
+        if (state != null && state.scroll != null) {
+          const { scroll } = state;
+          if ('from' in scroll) {
+            position = positionMap.get(scroll.from) || position;
+          } else if ('x' in scroll && 'y' in scroll) {
+            position = {
+              x: Number(scroll.x),
+              y: Number(scroll.y),
+            };
+          }
+        }
+        // 이벤트 리스너에 스크롤 위치가 전달되므로 따로 저장할 필요가 없다
+        window.scrollTo(position.x, position.y);
+      }
+
+      return () => {
+        window.removeEventListener('scroll', handleScroll);
+      };
+    },
+    [location],
+  );
+
+  return null;
+}
+
+export default withRouter(ScrollManager);

--- a/src/components/Modal/UnitSortModal.jsx
+++ b/src/components/Modal/UnitSortModal.jsx
@@ -10,12 +10,13 @@ function buildTargetLocation(location, option, scroll) {
   orderBy != null && params.set('order_by', orderBy);
   const search = params.toString();
 
+  const calculatedScroll = typeof scroll === 'function' ? scroll() : scroll;
   return {
     ...location,
     search: search === '' ? '' : `?${search}`,
     state: {
       ...(location.state || {}),
-      scroll,
+      scroll: calculatedScroll,
     },
   };
 }

--- a/src/components/Modal/UnitSortModal.jsx
+++ b/src/components/Modal/UnitSortModal.jsx
@@ -3,7 +3,7 @@ import { jsx } from '@emotion/core';
 import { withRouter } from 'react-router-dom';
 import { Modal, ModalItemGroup, ModalLinkItem } from '.';
 
-function buildTargetLocation(location, option) {
+function buildTargetLocation(location, option, scroll) {
   const params = new URLSearchParams(location.search);
   const { orderBy, orderType } = option;
   orderType != null && params.set('order_type', orderType);
@@ -13,10 +13,14 @@ function buildTargetLocation(location, option) {
   return {
     ...location,
     search: search === '' ? '' : `?${search}`,
+    state: {
+      ...(location.state || {}),
+      scroll,
+    },
   };
 }
 
-const UnitSortModal = ({ order, orderOptions, isActive, location, onClickModalBackground, horizontalAlign }) => (
+const UnitSortModal = ({ order, orderOptions, scroll, isActive, location, onClickModalBackground, horizontalAlign }) => (
   <Modal isActive={isActive} a11y="옵션" onClickModalBackground={onClickModalBackground} horizontalAlign={horizontalAlign}>
     <ModalItemGroup groupTitle="정렬 순서">
       <ul>
@@ -26,7 +30,7 @@ const UnitSortModal = ({ order, orderOptions, isActive, location, onClickModalBa
               scroll={false}
               title={option.title}
               isSelected={option.key === order}
-              to={buildTargetLocation(location, option)}
+              to={buildTargetLocation(location, option, scroll)}
               replace
             />
           </li>

--- a/src/components/ResponsivePaginator.jsx
+++ b/src/components/ResponsivePaginator.jsx
@@ -39,22 +39,23 @@ export const ResponsivePaginatorWithHandler = ({ currentPage, totalPages, onPage
   );
 };
 
-const ResponsivePaginator = ({ currentPage, totalPages, preserveScroll, history, location }) => {
+const ResponsivePaginator = ({ currentPage, totalPages, scroll, history, location }) => {
   const handlePageChange = React.useCallback(
     page => {
       const params = new URLSearchParams(location.search);
       params.set('page', page);
       const search = params.toString();
+      const calculatedScroll = typeof scroll === 'function' ? scroll() : scroll;
       history.push({
         ...location,
         search: search === '' ? '' : `?${search}`,
+        state: {
+          ...(location.state || {}),
+          scroll: calculatedScroll,
+        },
       });
-
-      if (!preserveScroll) {
-        window.scrollTo(0, 0);
-      }
     },
-    [history, location, preserveScroll],
+    [history, location],
   );
   return <ResponsivePaginatorWithHandler currentPage={currentPage} totalPages={totalPages} onPageChange={handlePageChange} />;
 };

--- a/src/components/SeriesList.jsx
+++ b/src/components/SeriesList.jsx
@@ -37,7 +37,7 @@ class SeriesList extends React.Component {
 
   makeEditingBarProps() {
     const { items, totalSelectedCount, onClickSelectAllBooks, onClickUnselectAllBooks, onEditingChange } = this.props;
-    const isSelectedAllBooks = totalSelectedCount === items.filter(item => item.purchased).length;
+    const isSelectedAllBooks = totalSelectedCount === (items || []).filter(item => item.purchased).length;
 
     return {
       totalSelectedCount,
@@ -97,8 +97,8 @@ class SeriesList extends React.Component {
       locationHref,
     } = this.props;
 
-    // Data 가져오는 상태면서 캐싱된 items가 없으면 Skeleton 노출
-    if (isFetching && items.length === 0) {
+    // items가 한번도 설정된 적이 없으면 Skeleton 노출
+    if (items == null) {
       return <SkeletonBooks viewType={ViewType.LANDSCAPE} />;
     }
 

--- a/src/components/SeriesList.jsx
+++ b/src/components/SeriesList.jsx
@@ -30,25 +30,6 @@ class SeriesList extends React.Component {
     this.seriesListRef = React.createRef();
   }
 
-  componentDidUpdate(prevProps) {
-    this.scrollToHeadWhenChangeOrder(prevProps);
-  }
-
-  scrollToHeadWhenChangeOrder(prevProps) {
-    const { currentOrder: order } = this.props;
-    const { currentOrder: prevOrder } = prevProps;
-
-    if (order !== prevOrder) {
-      setTimeout(() => {
-        if (!this.seriesListRef.current) {
-          return;
-        }
-
-        window.scrollTo(0, this.seriesListRef.current.offsetTop - 10);
-      }, 300);
-    }
-  }
-
   toggleEditingMode = () => {
     const { isEditing, onEditingChange } = this.props;
     onEditingChange && onEditingChange(!isEditing);
@@ -70,10 +51,22 @@ class SeriesList extends React.Component {
     };
   }
 
+  calculateScroll = () => {
+    const seriesList = this.seriesListRef.current;
+    return seriesList ? { x: 0, y: seriesList.offsetTop - 10 } : null;
+  };
+
   renderSeriesToolBar() {
     const { currentOrder, orderOptions } = this.props;
 
-    return <SeriesToolBar toggleEditingMode={this.toggleEditingMode} currentOrder={currentOrder} orderOptions={orderOptions} />;
+    return (
+      <SeriesToolBar
+        toggleEditingMode={this.toggleEditingMode}
+        currentOrder={currentOrder}
+        orderOptions={orderOptions}
+        scroll={this.calculateScroll}
+      />
+    );
   }
 
   getEmptyMessage(defaultMessage) {
@@ -148,7 +141,7 @@ class SeriesList extends React.Component {
 
   renderPaginator() {
     const { currentPage, totalPages } = this.props;
-    return <ResponsivePaginator currentPage={currentPage} totalPages={totalPages} preserveScroll />;
+    return <ResponsivePaginator currentPage={currentPage} totalPages={totalPages} scroll={this.calculateScroll} />;
   }
 
   render() {

--- a/src/components/SeriesToolBar/index.jsx
+++ b/src/components/SeriesToolBar/index.jsx
@@ -24,7 +24,7 @@ class SeriesToolBar extends React.Component {
   }
 
   renderOrder() {
-    const { currentOrder, orderOptions } = this.props;
+    const { currentOrder, orderOptions, scroll } = this.props;
     const { isSortModalShow } = this.state;
 
     if (!currentOrder || !orderOptions) {
@@ -49,6 +49,7 @@ class SeriesToolBar extends React.Component {
           horizontalAlign={Align.Left}
           order={currentOrder}
           orderOptions={orderOptions}
+          scroll={scroll}
           isActive={isSortModalShow}
           onClickModalBackground={() => {
             this.setState({

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -5,6 +5,7 @@ import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App';
+import ScrollManager from './ScrollManager';
 import { makeStoreWithApi } from './store';
 
 const store = makeStoreWithApi({}, {});
@@ -14,6 +15,7 @@ ReactDOM.render(
   <BrowserRouter>
     <Provider store={store}>
       <CacheProvider value={styleCache}>
+        <ScrollManager />
         <App />
       </CacheProvider>
     </Provider>

--- a/src/pages/shelves/detail/index.jsx
+++ b/src/pages/shelves/detail/index.jsx
@@ -196,8 +196,22 @@ function ShelfDetail(props) {
     [page, totalPages, history],
   );
 
+  function makeBackLocation() {
+    if (location.state && location.state.backLocation) {
+      const { backLocation } = location.state.backLocation;
+      return {
+        ...backLocation,
+        state: {
+          ...(backLocation.state || {}),
+          scroll: { from: backLocation.key },
+        },
+      };
+    }
+    return URLMap[PageType.SHELVES].as;
+  }
+
   function renderShelfBar() {
-    const backLocation = location.state ? location.state.backLocation : URLMap[PageType.SHELVES].as;
+    const backLocation = makeBackLocation();
     const left = <Title title={name} showCount={totalBookCount != null} totalCount={totalBookCount} to={backLocation} />;
     return <FlexBar css={styles.shelfBar} flexLeft={left} />;
   }

--- a/src/pages/unit/index.jsx
+++ b/src/pages/unit/index.jsx
@@ -231,7 +231,7 @@ function Unit(props) {
         unit={unit}
         primaryBookId={primaryBookId}
         primaryItem={primaryItem}
-        items={items}
+        items={items || []}
         bookDescription={bookDescription}
         bookStarRating={bookStarRating}
         downloadable

--- a/src/pages/unit/index.jsx
+++ b/src/pages/unit/index.jsx
@@ -58,7 +58,14 @@ function extractOptions({ location, path, params }) {
 
 function makeBackLocation({ location, match }) {
   if (location.state?.backLocation != null) {
-    return location.state.backLocation;
+    const { backLocation } = location.state;
+    return {
+      ...backLocation,
+      state: {
+        ...(backLocation.state || {}),
+        scroll: { from: backLocation.key },
+      },
+    };
   }
 
   const searchParams = new URLSearchParams(location.search);

--- a/src/services/unitPage/selectors.js
+++ b/src/services/unitPage/selectors.js
@@ -23,8 +23,8 @@ export const getItemsByPage = createSelector(
   (_, options) => options.page,
   (dataState, page) => {
     const { itemIdsForPage, items } = dataState;
-    const itemIds = itemIdsForPage[page] || [];
-    return itemIds.map(itemId => items[itemId]);
+    const itemIds = itemIdsForPage[page];
+    return itemIds && itemIds.map(itemId => items[itemId]);
   },
 );
 


### PR DESCRIPTION
하나의 어플리케이션처럼 동작하는 내 서재의 특성상 셀렉트에서의 스크롤 처리보다 더 많은 기능이 필요할 것으로 판단해, 스크롤 위치를 기억하고 조작하는 컴포넌트를 작성했습니다.

---

새로 추가된 `ScrollManager` 컴포넌트는 스크롤 위치를 기억하고 `location`의 변화에 반응해 적절하게 스크롤을 조작합니다.
- 페이지가 변할 때 이전 페이지의 스크롤 위치를 `location.key`와 함께 기록합니다.
- 한 번 방문했던 페이지(`key`가 기록에 있음)는 스크롤을 조작하지 않습니다. 브라우저가 스크롤을 이동시키기 때문입니다.
- `location.state.scroll`에 기존 페이지의 `key` 값이 지정되어 있다면 컴포넌트가 기억하고 있던 해당 페이지의 스크롤 위치를 가져와 복사합니다.
  - 이 기능은 "책 상세 페이지에서 책 목록 페이지로 바로 이동"할 때 스크롤 위치를 복원하기 위해 필요합니다. 이 기능은 책 목록 페이지를 history에 쌓는 것으로 구현되어 있는데, 브라우저에서 책 목록 페이지가 나올 때까지 뒤로 가기를 수행할 수 없기 때문입니다. 이 경우 `key`는 새로 부여되기 때문에 기존 페이지의 `key`로 스크롤 위치를 가져와 복사할 필요가 있습니다.
- `location.state.scroll`에 스크롤 위치가 명시적으로 지정되어 있으면 그 위치로 이동합니다.