### PR TITLE
서점으로 넘길 때 Referer에 슬래시 두 번 들어가는 문제 수정

### DIFF
--- a/src/components/SerialPreferenceBooks/index.jsx
+++ b/src/components/SerialPreferenceBooks/index.jsx
@@ -4,7 +4,6 @@ import { Book } from '@ridi/web-ui/dist/index.node';
 import React from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
-import config from '../../config';
 import Genre from '../../constants/category';
 import { toggleItem } from '../../services/selection/actions';
 import { getSelectedItems } from '../../services/selection/selectors';
@@ -13,7 +12,7 @@ import SeriesCompleteIcon from '../../svgs/SeriesCompleteIcon.svg';
 import BookMetaData from '../../utils/bookMetaData';
 import { EmptySeries } from '../../utils/dataObject';
 import { notifyMessage } from '../../utils/sentry';
-import { makeWebViewerUri, makeRidiStoreUri } from '../../utils/uri';
+import { makeLocationHref, makeWebViewerUri, makeRidiStoreUri } from '../../utils/uri';
 import BooksWrapper from '../BooksWrapper';
 import FullButton from './FullButton';
 import * as serialPreferenceStyles from './styles';
@@ -105,7 +104,7 @@ const toProps = ({
 
 class SerialPreferenceBooks extends React.Component {
   render() {
-    const { items, platformBookDTO, selectedBooks, isSelectMode, onSelectedChange, viewType, locationHref } = this.props;
+    const { items, location, platformBookDTO, selectedBooks, isSelectMode, onSelectedChange, viewType } = this.props;
 
     return (
       <BooksWrapper
@@ -126,7 +125,7 @@ class SerialPreferenceBooks extends React.Component {
             isSelected,
             onSelectedChange,
             viewType,
-            locationHref,
+            locationHref: makeLocationHref(location),
           });
           const { thumbnailLink } = libraryBookProps;
 
@@ -142,14 +141,9 @@ class SerialPreferenceBooks extends React.Component {
   }
 }
 
-const mapStateToProps = (state, props) => {
-  const { pathname, search } = props.location;
-  const locationHref = `${config.BASE_URL}${pathname}${search}`;
-  return {
-    locationHref,
-    selectedBooks: getSelectedItems(state),
-  };
-};
+const mapStateToProps = state => ({
+  selectedBooks: getSelectedItems(state),
+});
 
 const mapDispatchToProps = {
   onSelectedChange: toggleItem,

--- a/src/components/SeriesList.jsx
+++ b/src/components/SeriesList.jsx
@@ -3,14 +3,13 @@ import { jsx } from '@emotion/core';
 import React from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
-import config from '../config';
 import { OrderOptions } from '../constants/orderOptions';
 import { UnitType } from '../constants/unitType';
 import ViewType from '../constants/viewType';
 import { ResponsiveBooks } from '../pages/base/Responsive';
 import { getTotalSelectedCount } from '../services/selection/selectors';
 import BookOutline from '../svgs/BookOutline.svg';
-import { makeRidiSelectUri, makeRidiStoreUri, makeWebViewerUri } from '../utils/uri';
+import { makeLocationHref, makeRidiSelectUri, makeRidiStoreUri, makeWebViewerUri } from '../utils/uri';
 import { ACTION_BAR_HEIGHT } from './ActionBar/styles';
 import { Books } from './Books';
 import Editable from './Editable';
@@ -93,9 +92,10 @@ class SeriesList extends React.Component {
       isFetching,
       unit,
       linkWebviewer,
+      location,
       emptyProps: { message = '구매/대여하신 책이 없습니다.' } = {},
-      locationHref,
     } = this.props;
+    const locationHref = makeLocationHref(location);
 
     // items가 한번도 설정된 적이 없으면 Skeleton 노출
     if (items == null) {
@@ -165,21 +165,8 @@ class SeriesList extends React.Component {
   }
 }
 
-const mapStateToProps = (state, props) => {
-  const { pathname, search } = props.location;
-  const locationHref = `${config.BASE_URL}${pathname}${search}`;
+const mapStateToProps = state => ({
+  totalSelectedCount: getTotalSelectedCount(state),
+});
 
-  return {
-    locationHref,
-    totalSelectedCount: getTotalSelectedCount(state),
-  };
-};
-
-const mapDispatchToProps = {};
-
-export default withRouter(
-  connect(
-    mapStateToProps,
-    mapDispatchToProps,
-  )(SeriesList),
-);
+export default withRouter(connect(mapStateToProps)(SeriesList));

--- a/src/components/UnitDetailView/index.jsx
+++ b/src/components/UnitDetailView/index.jsx
@@ -6,7 +6,6 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import { createSelector } from 'reselect';
-import config from '../../config';
 import { UnitType } from '../../constants/unitType';
 import { getAdultVerification } from '../../services/account/selectors';
 import { getBook } from '../../services/book/selectors';
@@ -19,7 +18,7 @@ import NoneDashedArrowRight from '../../svgs/NoneDashedArrowRight.svg';
 import Star from '../../svgs/Star.svg';
 import BookMetaData from '../../utils/bookMetaData';
 import { thousandsSeperator } from '../../utils/number';
-import { makeRidiSelectUri, makeRidiStoreUri, makeWebViewerUri } from '../../utils/uri';
+import { makeLocationHref, makeRidiSelectUri, makeRidiStoreUri, makeWebViewerUri } from '../../utils/uri';
 import SkeletonUnitDetailView from '../Skeleton/SkeletonUnitDetailView';
 import * as styles from './styles';
 
@@ -134,7 +133,8 @@ class UnitDetailView extends React.Component {
   }
 
   renderReadLatestButton() {
-    const { readableLatest, unit, book, readLatestBookData, locationHref, fetchingReadLatest } = this.props;
+    const { location, readableLatest, unit, book, readLatestBookData, fetchingReadLatest } = this.props;
+    const locationHref = makeLocationHref(location);
 
     if (!readableLatest) {
       return null;
@@ -262,11 +262,6 @@ class UnitDetailView extends React.Component {
 }
 
 const mapStateToPropsFactory = () => {
-  const getLocationHref = location => {
-    const { pathname, search } = location;
-    return `${config.BASE_URL}${pathname}${search}`;
-  };
-
   const selectBookMetadata = createSelector(
     getBook,
     (state, primaryBookId, unit) => unit,
@@ -274,7 +269,6 @@ const mapStateToPropsFactory = () => {
   );
 
   return (state, props) => ({
-    locationHref: getLocationHref(props.location),
     readLatestBookData: props.unit ? getReadLatestData(state, props.unit.id) : null,
     fetchingReadLatest: getFetchingReadLatest(state),
     book: props.primaryBookId && getBook(state, props.primaryBookId),

--- a/src/utils/uri.js
+++ b/src/utils/uri.js
@@ -25,6 +25,12 @@ export const convertUriToAndroidIntentUri = (uri, packageName) => {
   )}#Intent;scheme=${scheme};action=android.intent.action.VIEW;category=android.intent.category.BROWSABLE;package=${packageName};end`;
 };
 
+export const makeLocationHref = location => {
+  const url = new URL(location.pathname, config.BASE_URL);
+  url.search = location.search;
+  return url.toString();
+};
+
 // 개발용 웹뷰어가 없기 때문에 도메인을 고정한다.
 export const makeWebViewerUri = (bookId, currentUri) => {
   const webViewerBaseUrl = new URL(`books/${bookId}`, 'https://view.ridibooks.com');


### PR DESCRIPTION
`URL` 객체를 사용해 URL을 조합합니다.

나중에 React Router가 `useLocation` 같은 훅을 제공해주면 이 로직을 훅으로 재작성해볼 수도 있겠네요.