### PR TITLE
도서 노출 조건 수정

### DIFF
--- a/src/components/SeriesList.jsx
+++ b/src/components/SeriesList.jsx
@@ -96,12 +96,12 @@ class SeriesList extends React.Component {
     const locationHref = makeLocationHref(location);
 
     // items가 한번도 설정된 적이 없으면 Skeleton 노출
-    if (items == null) {
+    if (isFetching || items == null) {
       return <SkeletonBooks viewType={ViewType.LANDSCAPE} />;
     }
 
     // Data 가져오는 상태가 아니면서 Items가 비어있으면 0
-    if (!isFetching && items.length === 0) {
+    if (items.length === 0) {
       return <Empty IconComponent={BookOutline} message={this.getEmptyMessage(message)} />;
     }
 


### PR DESCRIPTION
도서 정보가 없는데도 book 을 렌더해서 에러가 발생하고 있습니다.

fetching 여부는 스켈레톤 노출 판단에 사용하고
도서가 없을 경우 바로 empty 가 노출되도록 조건을 수정 했습니다.