### PR TITLE
잘못된 object destructuring 수정

### DIFF
--- a/src/services/shelf/reducers.js
+++ b/src/services/shelf/reducers.js
@@ -175,7 +175,7 @@ const shelfReducer = produce((draft, action) => {
       break;
     }
     case LOAD_SHELF_BOOK_COUNT: {
-      const uuid = action.payload;
+      const { uuid } = action.payload;
       if (draft.shelf[uuid] == null) {
         draft.shelf[uuid] = makeBaseShelfData(uuid);
       }


### PR DESCRIPTION
loadShelfBook 이 먼저 초기화를 하기 때문에 서비스에 문제는 없지만 store에 잘못된 default 값이 한번 쌓이고 있었습니다.