### PR TITLE
책장 책 목록 페이지네이션 안 되는 문제 수정

### DIFF
--- a/src/pages/shelves/detail/index.jsx
+++ b/src/pages/shelves/detail/index.jsx
@@ -63,10 +63,12 @@ function ShelfDetail(props) {
   const [isAdding, setIsAdding] = React.useState(false);
 
   React.useEffect(() => {
+    loadShelfBookCount(uuid);
+  }, [uuid]);
+  React.useEffect(() => {
     clearSelectedBooks();
     loadShelfBooks(uuid, pageOptions);
-    loadShelfBookCount(uuid);
-  }, [location]);
+  }, [location, uuid]);
 
   const toggleEditingMode = React.useCallback(() => {
     clearSelectedBooks();
@@ -164,6 +166,9 @@ function ShelfDetail(props) {
   );
 
   React.useEffect(() => {
+    if (totalPages == null) {
+      return;
+    }
     const newPage = Math.max(Math.min(page, totalPages), 1);
     if (page !== newPage) {
       const linkProps = makeLinkProps(


### PR DESCRIPTION
페이지 이동 중에 책장 책 권수가 `null`으로 잡히면서 총 페이지 수가 1페이지가 되는 문제가 있었습니다.